### PR TITLE
Fix some strings in pt_BR translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -16,14 +16,14 @@ msgstr ""
 "Project-Id-Version: sylpheed\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-11-20 13:13+0900\n"
-"PO-Revision-Date: 2015-05-19 00:03-0200\n"
+"PO-Revision-Date: 2015-05-19 07:22-0200\n"
 "Last-Translator: Felipe Braga <fbobraga@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
 #: libsylph/account.c:55
@@ -2406,7 +2406,7 @@ msgstr "/E_xcluir pasta"
 
 #: src/folderview.c:259 src/folderview.c:283
 msgid "/Empty _junk"
-msgstr "/Esvaziar pata de _spam"
+msgstr "/Esvaziar pasta de _spam"
 
 #: src/folderview.c:260 src/folderview.c:284
 msgid "/Empty _trash"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,19 +10,21 @@
 # Debian-BR <debian-l10n-portuguese@lists.debian.org>
 # Gustavo Noronha Silva <kov@debian.org>
 # Ricardo Nabinger Sanchez <rnsanchez@gmail.com>, 2010.
-#
-#
+# Felipe Braga <fbobraga@gmail.com>, 2015.
 msgid ""
 msgstr ""
 "Project-Id-Version: sylpheed\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-11-20 13:13+0900\n"
-"PO-Revision-Date: 2011-01-21 07:33-0200\n"
-"Last-Translator: Alexandre Erwin Ittner <alexandre@ittner.com.br>\n"
-"Language-Team: Portuguese/Brazil <(none)>\n"
+"PO-Revision-Date: 2015-05-19 00:03-0200\n"
+"Last-Translator: Felipe Braga <fbobraga@gmail.com>\n"
+"Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Virtaal 0.7.1\n"
 
 #: libsylph/account.c:55
 msgid "Reading all config for each account...\n"
@@ -2404,7 +2406,7 @@ msgstr "/E_xcluir pasta"
 
 #: src/folderview.c:259 src/folderview.c:283
 msgid "/Empty _junk"
-msgstr "/Esvaziar _lixeira"
+msgstr "/Esvaziar pata de _spam"
 
 #: src/folderview.c:260 src/folderview.c:284
 msgid "/Empty _trash"
@@ -2601,11 +2603,11 @@ msgstr "Você realmente deseja excluir todas as mensagens da lixeira?"
 
 #: src/folderview.c:2810
 msgid "Empty junk"
-msgstr "Esvaziar lixeira"
+msgstr "Esvaziar pasta de spam"
 
 #: src/folderview.c:2811
 msgid "Delete all messages in the junk folder?"
-msgstr "Excluir todas as mensagens da lixeira?"
+msgstr "Excluir todas as mensagens da pasta de spam?"
 
 #: src/folderview.c:2858
 #, c-format


### PR DESCRIPTION
The word "junk" was incorrect translated as "lixeira" (which corresponds to "trash") in pt_BR, making some menus itens incorrect/confusing: eg., **both** "empty trash" and "empty junk" was translated as "esvaziar lixeira"...
